### PR TITLE
Documentation typo fix: claim-schema.md

### DIFF
--- a/mkdocs/docs/protocol/claim-schema.md
+++ b/mkdocs/docs/protocol/claim-schema.md
@@ -22,7 +22,7 @@ The `countryCode` should be stored in IndexDataSlotA while the `documentType` in
 ...
 ```
 
-A claim issuer could reuse [exisitng claim schemas](https://github.com/iden3/claim-schema-vocab/tree/main/schemas/json-ld) or create new ones from scratch.
+A claim issuer could reuse [existing claim schemas](https://github.com/iden3/claim-schema-vocab/tree/main/schemas/json-ld) or create new ones from scratch.
 
 ## Example: Auth Claim Schema 
 


### PR DESCRIPTION
L25: `exisitng` -> `existing`