### PR TITLE
Fix children position for 1 in leaf nodes

### DIFF
--- a/mkdocs/docs/services/rhs.md
+++ b/mkdocs/docs/services/rhs.md
@@ -135,7 +135,7 @@ Note, that the Hash field of the Node struct is a hash of the Children field, ho
 If identity holder wants to publish his identity state to RHS he needs to do the following:
 
 1. Save the state of identity to RHS `{ Hash: state, Children: [ClaimsTreeRoot, RevocationTreeRoot, RootsTreeRoot] }`
-2. Save the nodes of Revocation tree and Roots tree to RHS for the intermediate nodes `{ Hash: hash, Children: [left, right] }` where left and right are the hashes of the children of the node. And for the leaf nodes `{ Hash: hash, Children: [1, key, value] }`
+2. Save the nodes of Revocation tree and Roots tree to RHS for the intermediate nodes `{ Hash: hash, Children: [left, right] }` where left and right are the hashes of the children of the node. And for the leaf nodes `{ Hash: hash, Children: [key, value, 1] }`
 
 ### Example with **off-chain RHS storage**:
 


### PR DESCRIPTION
- Fix children position for 1 in leaf nodes. Implementations in JS and Go for leave nodes are 
```
{ Hash: hash, Children: [key, value, 1] } 
```